### PR TITLE
Use one command [craft/up] instead of two commands

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -45,8 +45,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Script runner
      *
-     * Runs migrate/all only if Craft is installed
-     * Runs project-config/apply if enabled in config/general.php
+     * Runs up command if Craft is installed
      */
     public function runCommands(): bool
     {
@@ -63,20 +62,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         }
 
         $this->io->write(PHP_EOL . "▶ <info>Craft auto migrate</info> [START]");
-        $cmd = new CraftCommand(["migrate/all"], new ProcessExecutor($this->io));
-
-        if ($cmd->run()) {
-            $this->io->write(PHP_EOL . "▶ <info>Craft auto migrate</info> [migrate/all]");
-            $this->io->write(PHP_EOL . $cmd->getOutput());
-        } else {
-            $this->io->writeError(PHP_EOL . "▶ <info>Craft auto migrate</info> [migrate/all ERROR]");
-            $this->io->writeError(PHP_EOL . $cmd->getErrorOutput());
-            return false;
-        }
-
 
         if ($this->hasProjectConfig()) {
-            $args = ["project-config/apply"];
+            $args = ["up"];
 
             if (getenv('PROJECT_CONFIG_FORCE_APPLY') == 1) {
                 $args[] = '--force';
@@ -85,7 +73,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $cmd = new CraftCommand($args, new ProcessExecutor($this->io));
 
             if ($cmd->run()) {
-                $this->io->write(PHP_EOL . "▶ <info>Craft auto migrate</info> [project-config/apply]");
+                $this->io->write(PHP_EOL . "▶ <info>Craft auto migrate</info> [up]");
                 $this->io->write(PHP_EOL . $cmd->getOutput());
 
                 // Remove project.yaml during deployment (non-interactive mode)
@@ -98,10 +86,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
 
             } else {
-                $this->io->writeError(PHP_EOL . "▶ <info>Craft auto migrate</info> [project-config/apply ERROR]");
+                $this->io->writeError(PHP_EOL . "▶ <info>Craft auto migrate</info> [up ERROR]");
                 $this->io->writeError(PHP_EOL . $cmd->getErrorOutput());
                 return false;
             }
+        } else {
+            $this->io->write(PHP_EOL . "▶ <info>Project Config not found.</info>");
         }
 
         $this->io->write(PHP_EOL . "▶ <info>Craft auto migrate</info> [END]" . PHP_EOL);


### PR DESCRIPTION
We have recently updated our deployment scripts after speaking with CraftCMS support.

Instead of calling `migrate/all` and `project-config/apply` separately, we are now using the single command `up`.

This command handles migrations and project config in the correct order, with the added benefit that it won’t continue applying config if the migrations fail.

The up command also supports the --force flag https://craftcms.com/docs/4.x/console-commands.html#up

There may be reasons why you'd want to continue calling them separately, but I made a change to this file to demonstrate what a single command would look like.

(I have not tested this change).